### PR TITLE
Units

### DIFF
--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -11,6 +11,7 @@ def capacitor_pods
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCommunityKeepAwake', :path => '../../node_modules/@capacitor-community/keep-awake'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
+  pod 'CapacitorClipboard', :path => '../../node_modules/@capacitor/clipboard'
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
   pod 'CapacitorStorage', :path => '../../node_modules/@capacitor/storage'

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/service-worker": "~12.0.1",
         "@capacitor-community/keep-awake": "^2.1.0",
         "@capacitor/app": "1.0.2",
+        "@capacitor/clipboard": "^1.0.2",
         "@capacitor/core": "3.2.0",
         "@capacitor/haptics": "1.0.2",
         "@capacitor/ios": "3.2.0",
@@ -2450,6 +2451,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@capacitor/clipboard": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/clipboard/-/clipboard-1.0.2.tgz",
+      "integrity": "sha512-uYed+v10UjZapn1v5pRbRAJd6od6gUW1ROuu/pO0JxMABVV3SwmwqQbu9y6K8l4ptqNH5ZmpqkFmc4Qz0lN3JA==",
+      "peerDependencies": {
+        "@capacitor/core": "^3.0.0"
       }
     },
     "node_modules/@capacitor/core": {
@@ -21794,6 +21803,12 @@
           }
         }
       }
+    },
+    "@capacitor/clipboard": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/clipboard/-/clipboard-1.0.2.tgz",
+      "integrity": "sha512-uYed+v10UjZapn1v5pRbRAJd6od6gUW1ROuu/pO0JxMABVV3SwmwqQbu9y6K8l4ptqNH5ZmpqkFmc4Qz0lN3JA==",
+      "requires": {}
     },
     "@capacitor/core": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/service-worker": "~12.0.1",
     "@capacitor-community/keep-awake": "^2.1.0",
     "@capacitor/app": "1.0.2",
+    "@capacitor/clipboard": "^1.0.2",
     "@capacitor/core": "3.2.0",
     "@capacitor/haptics": "1.0.2",
     "@capacitor/ios": "3.2.0",

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -14,12 +14,12 @@
       <summary><ion-note>About the developer</ion-note></summary>
       <ion-list lines="none">
         <p class="ion-text-justify">
-          Duncan Law is currently a third-year undergraduate student studying Engineering Science
-          in the University of Oxford. He also competes in
+          Duncan Law is currently a third-year undergraduate studying Engineering Science
+          in the University of Oxford. He competes in
           <a href="https://www.britishpowerlifting.org/">British Powerlifting</a>
           (under the
           <a href="https://www.powerlifting.sport/">IPF</a>)
-          as a Junior lifter in the 83kg weight category.
+          as a Junior lifter in the 83kg weight class.
         </p>
         <ion-item>
           <ion-button fill="none" size="clear" href="https://www.openpowerlifting.org/u/duncanlaw">
@@ -59,6 +59,9 @@
     </ion-button>
   </ion-content>
   <ion-footer class="ion-padding ion-text-justify">
+    <ion-note>
+      <ion-label position="fixed">Units</ion-label>
+    </ion-note>
     <ion-segment
       [(ngModel)]="weightUnitService.userUnit"
       (ionChange)="weightUnitService.setUnit()"

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -63,8 +63,8 @@
       <ion-label position="fixed">Units</ion-label>
     </ion-note>
     <ion-segment
-      [(ngModel)]="weightUnitService.userUnit"
-      (ionChange)="weightUnitService.setUnit()"
+      [ngModel]="weightUnitService.userUnit | async"
+      (ionChange)="weightUnitService.setUnit($event)"
     >
       <ion-segment-button value="kg">
         <ion-label>kilogram</ion-label>

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -59,6 +59,8 @@
     </ion-button>
   </ion-content>
   <ion-footer class="ion-padding ion-text-justify">
+    <app-utilities></app-utilities>
+    <br/>
     <ion-note>
       <ion-label position="fixed">Units</ion-label>
     </ion-note>

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -64,10 +64,10 @@
       (ionChange)="weightUnitService.setUnit()"
     >
       <ion-segment-button value="kg">
-        <ion-label>kg</ion-label>
+        <ion-label>kilogram</ion-label>
       </ion-segment-button>
       <ion-segment-button value="lb">
-        <ion-label>lb</ion-label>
+        <ion-label>pound</ion-label>
       </ion-segment-button>
     </ion-segment>
     <br/>

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -59,6 +59,18 @@
     </ion-button>
   </ion-content>
   <ion-footer class="ion-padding ion-text-justify">
+    <ion-segment
+      [(ngModel)]="weightUnitService.userUnit"
+      (ionChange)="weightUnitService.setUnit()"
+    >
+      <ion-segment-button value="kg">
+        <ion-label>kg</ion-label>
+      </ion-segment-button>
+      <ion-segment-button value="lb">
+        <ion-label>lb</ion-label>
+      </ion-segment-button>
+    </ion-segment>
+    <br/>
     <ion-note>
       Have an issue, or want to suggest a feature? Send an email
       <a href="mailto:lawdtk@gmail.com">here</a>

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -17,8 +17,6 @@ export class AboutComponent implements OnInit {
   ngOnInit() {
   }
 
-  onClickButton(): void {
-    this.menuController.close();
-  }
+  onClickButton = (): Promise<boolean> => this.menuController.close();
 
 }

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { WeightUnitService } from '../settings/weight-unit.service';
 import { MenuController } from '@ionic/angular';
 
 @Component({
@@ -9,6 +10,7 @@ import { MenuController } from '@ionic/angular';
 export class AboutComponent implements OnInit {
 
   constructor(
+    public weightUnitService: WeightUnitService,
     private menuController: MenuController
   ) { }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,9 +10,10 @@ import { ServiceWorkerModule } from '@angular/service-worker';
 import { environment } from '../environments/environment';
 import { AboutComponent } from './about/about.component';
 import { FormsModule } from '@angular/forms';
+import { UtilitiesComponent } from './utilities/utilities.component';
 
 @NgModule({
-  declarations: [AppComponent, AboutComponent],
+  declarations: [AppComponent, AboutComponent, UtilitiesComponent],
   entryComponents: [],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { environment } from '../environments/environment';
 import { AboutComponent } from './about/about.component';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent, AboutComponent],
@@ -24,7 +25,8 @@ import { AboutComponent } from './about/about.component';
       // Register the ServiceWorker as soon as the app is stable
       // or after 30 seconds (whichever comes first).
       registrationStrategy: 'registerWhenStable:30000'
-    })
+    }),
+    FormsModule
   ],
   providers: [{ provide: RouteReuseStrategy, useClass: IonicRouteStrategy }],
   bootstrap: [AppComponent],

--- a/src/app/coefficients/coefficients.page.html
+++ b/src/app/coefficients/coefficients.page.html
@@ -64,7 +64,7 @@
                       name="weight"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='total'">
                     <ion-label position="fixed">total</ion-label>
@@ -74,7 +74,7 @@
                       name="total"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='threeLifts'">
                     <ion-label position="fixed">squat</ion-label>
@@ -84,7 +84,7 @@
                       name="sq"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='threeLifts'">
                     <ion-label position="fixed">bench</ion-label>
@@ -94,7 +94,7 @@
                       name="bp"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='threeLifts'">
                     <ion-label position="fixed">deadlift</ion-label>
@@ -104,7 +104,7 @@
                       [ngModel]="userDl"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='onlyBP'">
                     <ion-label position="fixed">bench</ion-label>
@@ -114,11 +114,11 @@
                       name="bp"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                   </ion-item>
                 </ion-list>
                 <ion-row [hidden]="segmentSelected!=='threeLifts'" class="ion-justify-content-end ion-margin-top">
-                  = {{ userTotal || 0 }}{{ weightUnitService.userUnit }} total
+                  = {{ userTotal || 0 }}{{ weightUnitService.userUnit | async }} total
                 </ion-row>
                 <br/>
                 <ion-row id="result" *ngIf="!bluesSelected else bluesBlock">
@@ -157,7 +157,7 @@
                       name="goalBw"
                       (ionChange)="calcGoal(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                   </ion-item>
                 </ion-list>
                 <ion-label position="fixed">Goal</ion-label>
@@ -200,7 +200,7 @@
                         name="tTotal"
                         (ionChange)="calcDelta(coeff)"
                       ></ion-input>
-                      <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                      <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                     </ion-item>
                   </ion-list>
                   <ion-row
@@ -220,7 +220,7 @@
                 <ion-row id="result">
                   Goal total
                   <ion-text class="ion-padding-start" color="warning">
-                    {{ (goalTotal | number : '1.2-2') || 0 }}{{ weightUnitService.userUnit }}
+                    {{ (goalTotal | number : '1.2-2') || 0 }}{{ weightUnitService.userUnit | async }}
                   </ion-text>
                 </ion-row>
               </ion-card-content>

--- a/src/app/coefficients/coefficients.page.html
+++ b/src/app/coefficients/coefficients.page.html
@@ -220,7 +220,7 @@
                 <ion-row id="result">
                   Goal total
                   <ion-text class="ion-padding-start" color="warning">
-                    {{ goalTotal || 0 }}{{ weightUnitService.userUnit }}
+                    {{ (goalTotal | number : '1.2-2') || 0 }}{{ weightUnitService.userUnit }}
                   </ion-text>
                 </ion-row>
               </ion-card-content>

--- a/src/app/coefficients/coefficients.page.html
+++ b/src/app/coefficients/coefficients.page.html
@@ -64,7 +64,7 @@
                       name="weight"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">kg</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='total'">
                     <ion-label position="fixed">total</ion-label>
@@ -74,7 +74,7 @@
                       name="total"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">kg</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='threeLifts'">
                     <ion-label position="fixed">squat</ion-label>
@@ -84,7 +84,7 @@
                       name="sq"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">kg</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='threeLifts'">
                     <ion-label position="fixed">bench</ion-label>
@@ -94,7 +94,7 @@
                       name="bp"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">kg</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='threeLifts'">
                     <ion-label position="fixed">deadlift</ion-label>
@@ -104,7 +104,7 @@
                       [ngModel]="userDl"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">kg</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                   </ion-item>
                   <ion-item [hidden]="segmentSelected!=='onlyBP'">
                     <ion-label position="fixed">bench</ion-label>
@@ -114,11 +114,11 @@
                       name="bp"
                       (ngModelChange)="calcPoints(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">kg</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                   </ion-item>
                 </ion-list>
                 <ion-row [hidden]="segmentSelected!=='threeLifts'" class="ion-justify-content-end ion-margin-top">
-                  = {{ userTotal || 0 }}kg total
+                  = {{ userTotal || 0 }}{{ weightUnitService.userUnit }} total
                 </ion-row>
                 <br/>
                 <ion-row id="result" *ngIf="!bluesSelected else bluesBlock">
@@ -157,7 +157,7 @@
                       name="goalBw"
                       (ionChange)="calcGoal(coeff)"
                     ></ion-input>
-                    <ion-note slot="end">kg</ion-note>
+                    <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                   </ion-item>
                 </ion-list>
                 <ion-label position="fixed">Goal</ion-label>
@@ -200,7 +200,7 @@
                         name="tTotal"
                         (ionChange)="calcDelta(coeff)"
                       ></ion-input>
-                      <ion-note slot="end">kg</ion-note>
+                      <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                     </ion-item>
                   </ion-list>
                   <ion-row
@@ -220,7 +220,7 @@
                 <ion-row id="result">
                   Goal total
                   <ion-text class="ion-padding-start" color="warning">
-                    {{ goalTotal || 0 }}kg
+                    {{ goalTotal || 0 }}{{ weightUnitService.userUnit }}
                   </ion-text>
                 </ion-row>
               </ion-card-content>

--- a/src/app/coefficients/coefficients.page.html
+++ b/src/app/coefficients/coefficients.page.html
@@ -175,13 +175,13 @@
                 </ion-segment>
                 <br/>
 
-                <ion-row class="ion-align-items-center">
+                <ion-row class="ion-align-items-center" (click)="onClickCalc()">
                   <ion-col size="auto">
                     <ion-buttons>
-                      <ion-button [hidden]="calcDiff" (click)="onClickCalc()" id="blues">
+                      <ion-button [hidden]="calcDiff" id="blues">
                         <ion-icon size="large" name="add-circle"></ion-icon>
                       </ion-button>
-                      <ion-button [hidden]="!calcDiff" (click)="onClickCalc()" id="blues">
+                      <ion-button [hidden]="!calcDiff" id="blues">
                         <ion-icon size="large" name="close-circle"></ion-icon>
                       </ion-button>
                     </ion-buttons>

--- a/src/app/coefficients/coefficients.page.ts
+++ b/src/app/coefficients/coefficients.page.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NgForm } from '@angular/forms';
+import { WeightUnitService } from '../settings/weight-unit.service';
 
 import { CoeffService } from './coefficients.service';
 
@@ -26,7 +27,10 @@ export class CoefficientsPage implements OnInit {
   blueDiff: string;
   hBlueDiff: string;
 
-  constructor(private coeffService: CoeffService) { }
+  constructor(
+    public weightUnitService: WeightUnitService,
+    private coeffService: CoeffService
+  ) { }
 
   ngOnInit() {
     this.coeffService.checkGender().then(

--- a/src/app/coefficients/coefficients.page.ts
+++ b/src/app/coefficients/coefficients.page.ts
@@ -118,9 +118,7 @@ export class CoefficientsPage implements OnInit {
     }
   }
 
-  onClickCalc(): void {
-    this.calcDiff = !this.calcDiff;
-  }
+  onClickCalc = (): boolean => this.calcDiff = !this.calcDiff;;
 
   calcDelta(form: NgForm): void {
     if (this.goalTotal && form.value.tTotal) {

--- a/src/app/coefficients/coefficients.page.ts
+++ b/src/app/coefficients/coefficients.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { WeightUnitService } from '../settings/weight-unit.service';
 
@@ -9,7 +9,11 @@ import { CoeffService } from './coefficients.service';
   templateUrl: './coefficients.page.html',
   styleUrls: ['./coefficients.page.scss'],
 })
-export class CoefficientsPage implements OnInit {
+export class CoefficientsPage implements OnInit, OnDestroy {
+  // get TD form from template
+  // https://stackoverflow.com/questions/37093432/angular-2-template-driven-form-access-ngform-in-component
+  @ViewChild('coeff', { static: true }) coeffForm: NgForm;
+
   pointsSelected = 'IPF GL';
   segmentSelected = 'total';
   bluesSelected = false;
@@ -40,6 +44,15 @@ export class CoefficientsPage implements OnInit {
         }
       }
     );
+    this.weightUnitService.userUnit.subscribe(() => {
+      this.calcPoints(this.coeffForm);
+      this.calcGoal(this.coeffForm);
+      this.calcDelta(this.coeffForm);
+    });
+  }
+
+  ngOnDestroy() {
+    this.weightUnitService.userUnit.unsubscribe();
   }
 
   onChangeGender(form: NgForm): void {
@@ -114,20 +127,21 @@ export class CoefficientsPage implements OnInit {
 
   calcGoal(form: NgForm): void {
     if (this.userGender && form.value.goalBw && form.value.goalBlue) {
-    this.goalTotal = this.coeffService.calcBluesGoal(form);
+      this.goalTotal = this.coeffService.calcBluesGoal(form);
     }
   }
 
   onClickCalc = (): boolean => this.calcDiff = !this.calcDiff;;
 
   calcDelta(form: NgForm): void {
+    const unitUsed = this.weightUnitService.userUnit.value;
     if (this.goalTotal && form.value.tTotal) {
       if (this.goalTotal < form.value.tTotal) {
         this.blueDiff = 'achieved';
         this.hBlueDiff = 'achieved';
       } else {
-        this.blueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + this.weightUnitService.userUnit + ' remaining';
-        this.hBlueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + this.weightUnitService.userUnit + ' remaining';
+        this.blueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + unitUsed + ' remaining';
+        this.hBlueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + unitUsed + ' remaining';
       }
     }
   }

--- a/src/app/coefficients/coefficients.page.ts
+++ b/src/app/coefficients/coefficients.page.ts
@@ -128,8 +128,8 @@ export class CoefficientsPage implements OnInit {
         this.blueDiff = 'achieved';
         this.hBlueDiff = 'achieved';
       } else {
-        this.blueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + ' kg remaining';
-        this.hBlueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + ' kg remaining';
+        this.blueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + this.weightUnitService.userUnit + ' remaining';
+        this.hBlueDiff = (this.goalTotal - form.value.tTotal).toFixed(2) + this.weightUnitService.userUnit + ' remaining';
       }
     }
   }

--- a/src/app/coefficients/coefficients.service.ts
+++ b/src/app/coefficients/coefficients.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Storage } from '@capacitor/storage';
+import { WeightUnitService } from '../settings/weight-unit.service';
 
 import { NgForm } from '@angular/forms';
 import { GenderCoeff, GLModel } from '../numeric-tables/coefficient.model';
@@ -20,18 +21,20 @@ export class CoeffService {
   gender: string;
   benchOnly = false;
 
-  dotsScale: GenderCoeff = DOTSCOEFF;
+  private dotsScale: GenderCoeff = DOTSCOEFF;
 
-  glScale: GLModel = GLCOEFF;
+  private glScale: GLModel = GLCOEFF;
 
-  ipfScale: GenderCoeff = IPFCOEFF;
+  private ipfScale: GenderCoeff = IPFCOEFF;
 
-  wilksScale: GenderCoeff = WILKSCOEFF;
+  private wilksScale: GenderCoeff = WILKSCOEFF;
 
-  bluesConst: Blues = {
+  private bluesConst: Blues = {
     half: 500,
     full: 560
   };
+
+  constructor(private weightUnitService: WeightUnitService) {}
 
   setGender = async (userGender: string) => {
     const storeGender = (userGender === 'male') ? 'male' : 'female';
@@ -49,44 +52,16 @@ export class CoeffService {
     }
   };
 
-  dotsPoly(a: number, b: number, c: number, d: number, e: number, x: number): number {
-    const x2 = x*x;
-    const x3 = x2*x;
-    const x4 = x3*x;
-    return 500.0 / (a*x4 + b*x3 + c*x2 + d*x + e);
-  }
-
-  dotsFunction(bw: number, isMale: boolean): number {
-    const lBw = 40.0;
-    const uBw = (isMale)? 210.0 : 150.0;
-    bw = Math.min(Math.max(bw, lBw), uBw);
-    if (isMale) {
-      return this.dotsPoly(
-        -this.dotsScale.male.c1,
-        this.dotsScale.male.c2,
-        -this.dotsScale.male.c3,
-        this.dotsScale.male.c4,
-        -this.dotsScale.male.c5,
-        bw);
-    } else {
-      return this.dotsPoly(
-        -this.dotsScale.female.c1,
-        this.dotsScale.female.c2,
-        -this.dotsScale.female.c3,
-        this.dotsScale.female.c4,
-        -this.dotsScale.female.c5,
-        bw);
-    }
-  }
-
   calcDOTS(form: NgForm, total: number): number {
-    const bw: number = form.value.weight;
+    total = this.weightUnitService.convertToKilo(total);
+    const bw: number = this.weightUnitService.convertToKilo(form.value.weight);
     const isMale = (this.gender === 'male') ? true : (this.gender === 'female') ? false : null;
     return total*this.dotsFunction(bw, isMale);
   }
 
   calcGL(form: NgForm, total: number): number {
-    const bw: number = form.value.weight;
+    total = this.weightUnitService.convertToKilo(total);
+    const bw: number = this.weightUnitService.convertToKilo(form.value.weight);
     const sex = this.gender;
     const event = (this.benchOnly) ? 'b' : 'sbd';
     const equipment = 'raw'; // hardcoded for now until later implementation of an 'Equipped' selector
@@ -104,7 +79,8 @@ export class CoeffService {
   }
 
   calcIPF(form: NgForm, total: number): number {
-    const bw: number = form.value.weight;
+    total = this.weightUnitService.convertToKilo(total);
+    const bw: number = this.weightUnitService.convertToKilo(form.value.weight);
 
     let c1: number;
     let c2: number;
@@ -140,12 +116,13 @@ export class CoeffService {
     return (total > 0) ?
       500 + 100 * (
       (total - (c1 * Math.log(bw) - c2)) /
-      (c3 * Math.log(form.value.weight) - c4)
+      (c3 * Math.log(bw) - c4)
       ) : 0;
   }
 
   calcWilks(form: NgForm, total: number): number {
-    const bw: number = form.value.weight;
+    total = this.weightUnitService.convertToKilo(total);
+    const bw: number = this.weightUnitService.convertToKilo(form.value.weight);
 
     let c1: number;
     let c2: number;
@@ -189,6 +166,8 @@ export class CoeffService {
   }
 
   calcBluesGoal(form: NgForm): number {
+    const goalBw: number = this.weightUnitService.convertToKilo(form.value.goalBw);
+
     let c1: number;
     let c2: number;
     let c3: number;
@@ -210,7 +189,39 @@ export class CoeffService {
       this.bluesConst.full : (form.value.goalBlue === 'half') ?
       this.bluesConst.half : null;
 
-    return +(((goalIPF - 500) / 100) * (c3 * Math.log(form.value.goalBw) - c4) +
-      (c1 * Math.log(form.value.goalBw) - c2)).toFixed(2);
+    return this.weightUnitService.convertToLb(
+      (((goalIPF - 500) / 100) * (c3 * Math.log(goalBw) - c4) +
+      (c1 * Math.log(goalBw) - c2))
+    );
+  }
+
+  private dotsPoly(a: number, b: number, c: number, d: number, e: number, x: number): number {
+    const x2 = x*x;
+    const x3 = x2*x;
+    const x4 = x3*x;
+    return 500.0 / (a*x4 + b*x3 + c*x2 + d*x + e);
+  }
+
+  private dotsFunction(bw: number, isMale: boolean): number {
+    const lBw = 40.0;
+    const uBw = (isMale)? 210.0 : 150.0;
+    bw = Math.min(Math.max(bw, lBw), uBw);
+    if (isMale) {
+      return this.dotsPoly(
+        -this.dotsScale.male.c1,
+        this.dotsScale.male.c2,
+        -this.dotsScale.male.c3,
+        this.dotsScale.male.c4,
+        -this.dotsScale.male.c5,
+        bw);
+    } else {
+      return this.dotsPoly(
+        -this.dotsScale.female.c1,
+        this.dotsScale.female.c2,
+        -this.dotsScale.female.c3,
+        this.dotsScale.female.c4,
+        -this.dotsScale.female.c5,
+        bw);
+    }
   }
 }

--- a/src/app/coefficients/coefficients.service.ts
+++ b/src/app/coefficients/coefficients.service.ts
@@ -36,7 +36,7 @@ export class CoeffService {
 
   constructor(private weightUnitService: WeightUnitService) {}
 
-  setGender = async (userGender: string) => {
+  setGender = async (userGender: string): Promise<void> => {
     const storeGender = (userGender === 'male') ? 'male' : 'female';
 
     await Storage.set({
@@ -45,7 +45,7 @@ export class CoeffService {
     });
   };
 
-  checkGender = async () => {
+  checkGender = async (): Promise<void> => {
     const { value } = await Storage.get({ key: 'gender' });
     if (value) {
       this.gender = (value === 'male') ? 'male' : 'female';

--- a/src/app/loader/bar-loaded/bar-loaded.component.html
+++ b/src/app/loader/bar-loaded/bar-loaded.component.html
@@ -10,7 +10,7 @@
           <ion-card-subtitle>(collars automatically added)</ion-card-subtitle>
           <ion-list>
             <ion-item
-              *ngFor="let plate of plateCount; trackBy:loaderService.trackItems; let i = index;"
+              *ngFor="let plate of plateCount; trackBy:loaderService.trackItems"
             >
               <ion-row class="ion-align-items-center">
                 <ion-col>
@@ -23,7 +23,7 @@
                 <ion-col>
                   <ion-input
                     type="number"
-                    [(ngModel)]="plateCount[i].count"
+                    [(ngModel)]="plate.count"
                     [name]="plate.weight.toString()"
                     placeholder="0"
                     (ngModelChange)="onCountPlates()"

--- a/src/app/loader/bar-loaded/bar-loaded.component.html
+++ b/src/app/loader/bar-loaded/bar-loaded.component.html
@@ -15,7 +15,7 @@
               <ion-row class="ion-align-items-center">
                 <ion-col>
                   <ion-badge
-                    [color]="loaderService.getBadgeColor(plate.weight)"
+                    [color]="loaderService.getKGBadgeColor(plate.weight)"
                   >
                     {{ plate.weight }}kg
                   </ion-badge>

--- a/src/app/loader/bar-loader/bar-loader.component.html
+++ b/src/app/loader/bar-loader/bar-loader.component.html
@@ -41,7 +41,8 @@
             <div class="ion-text-center">Collar weight</div>
             <ion-segment
               (ionChange)="collarSegmentChanged($event); onCalcBar();"
-              [value]="compCollars"
+              [value]="weightUnitService.userUnit==='lb' ? false : compCollars"
+              [disabled]="weightUnitService.userUnit==='lb'"
             >
               <ion-segment-button [value]="false">
                 <ion-label>0kg</ion-label>
@@ -60,11 +61,11 @@
             </ion-button>
             <div [hidden]="!showPlates">
               <ion-list>
-                <ion-item *ngFor="let plate of plateCount; trackBy:loaderService.trackItems; let i = index;">
+                <ion-item *ngFor="let plate of plateCount[weightUnitService.userUnit]; trackBy:loaderService.trackItems; let i = index;">
                   <ion-row class="ion-align-items-center">
                     <ion-col>
                       <ion-badge
-                        [color]="loaderService.getBadgeColor(plate.weight)"
+                        [color]="loaderService.getKGBadgeColor(plate.weight)"
                       >
                         {{ plate.weight }}kg
                       </ion-badge>
@@ -72,7 +73,7 @@
                     <ion-col>
                       <ion-input
                         type="number"
-                        [(ngModel)]="plateCount[i].pairs"
+                        [(ngModel)]="plateCount[weightUnitService.userUnit][i].pairs"
                         (ngModelChange)="onCalcBar()"
                       ></ion-input>
                     </ion-col>
@@ -91,14 +92,15 @@
   <ion-row class="ion-align-items-center ion-justify-content-center" *ngIf="tWeight&&barLoaded">
     <ion-col class="ion-no-padding" style="margin: 0 3px 8px 3px;" size="auto">
       <ion-badge
-          [color]="loaderService.getBadgeColor(barWeight)"
+          [color]="loaderService.getKGBadgeColor(barWeight)"
         >
           BAR
         </ion-badge>
     </ion-col>
     <ion-col class="ion-no-padding" style="margin: 0 3px 8px 3px;" size="auto" *ngFor="let plate of barLoaded">
       <ion-badge
-          [color]="loaderService.getBadgeColor(plate)"
+          [color]="weightUnitService.userUnit === 'lb' ?
+            loaderService.handleUnits.lb.colours(plate) : loaderService.handleUnits.kg.colours(plate)"
           [style.padding-top]="loaderService.getHeight(plate)"
           [style.padding-bottom]="loaderService.getHeight(plate)"
           style="padding-left: 3px; padding-right: 3px;"
@@ -106,9 +108,13 @@
           {{ plate }}
         </ion-badge>
     </ion-col>
-    <ion-col class="ion-no-padding" style="margin: 0 3px 8px 3px;" size="auto" *ngIf="compCollars">
+    <ion-col
+      class="ion-no-padding"
+      style="margin: 0 3px 8px 3px;"
+      size="auto"
+      *ngIf="compCollars && weightUnitService.userUnit!=='lb'">
       <ion-badge
-        [color]="loaderService.getBadgeColor(2.5)"
+        [color]="loaderService.getKGBadgeColor(2.5)"
         style="padding-top: 5px; padding-bottom: 5px;"
       >
         C

--- a/src/app/loader/bar-loader/bar-loader.component.html
+++ b/src/app/loader/bar-loader/bar-loader.component.html
@@ -41,7 +41,7 @@
             <div class="ion-text-center">Collar weight</div>
             <ion-segment
               (ionChange)="collarSegmentChanged($event); onCalcBar();"
-              [value]="weightUnitService.userUnit==='lb' ? false : compCollars"
+              [value]="compCollars"
               [disabled]="weightUnitService.userUnit==='lb'"
             >
               <ion-segment-button [value]="false">

--- a/src/app/loader/bar-loader/bar-loader.component.html
+++ b/src/app/loader/bar-loader/bar-loader.component.html
@@ -14,7 +14,7 @@
                 [(ngModel)]="tWeight"
                 (ngModelChange)="onCalcBar()"
               ></ion-input>
-              <ion-note slot="end">kg</ion-note>
+              <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
             </ion-item>
           </ion-list>
           <ion-button

--- a/src/app/loader/bar-loader/bar-loader.component.html
+++ b/src/app/loader/bar-loader/bar-loader.component.html
@@ -14,7 +14,7 @@
                 [(ngModel)]="tWeight"
                 (ngModelChange)="onCalcBar()"
               ></ion-input>
-              <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+              <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
             </ion-item>
           </ion-list>
           <ion-button
@@ -42,7 +42,7 @@
             <ion-segment
               (ionChange)="collarSegmentChanged($event); onCalcBar();"
               [value]="compCollars"
-              [disabled]="weightUnitService.userUnit==='lb'"
+              [disabled]="(weightUnitService.userUnit | async) === 'lb'"
             >
               <ion-segment-button [value]="false">
                 <ion-label>0kg</ion-label>
@@ -61,7 +61,7 @@
             </ion-button>
             <div [hidden]="!showPlates">
               <ion-list>
-                <ion-item *ngFor="let plate of plateCount[weightUnitService.userUnit]; trackBy:loaderService.trackItems; let i = index;">
+                <ion-item *ngFor="let plate of plateCount[weightUnitService.userUnit | async]; trackBy:loaderService.trackItems">
                   <ion-row class="ion-align-items-center">
                     <ion-col>
                       <ion-badge
@@ -73,7 +73,7 @@
                     <ion-col>
                       <ion-input
                         type="number"
-                        [(ngModel)]="plateCount[weightUnitService.userUnit][i].pairs"
+                        [(ngModel)]="plate.pairs"
                         (ngModelChange)="onCalcBar()"
                       ></ion-input>
                     </ion-col>
@@ -99,7 +99,7 @@
     </ion-col>
     <ion-col class="ion-no-padding" style="margin: 0 3px 8px 3px;" size="auto" *ngFor="let plate of barLoaded">
       <ion-badge
-          [color]="weightUnitService.userUnit === 'lb' ?
+          [color]="(weightUnitService.userUnit | async) === 'lb' ?
             loaderService.handleUnits.lb.colours(plate) : loaderService.handleUnits.kg.colours(plate)"
           [style.padding-top]="loaderService.getHeight(plate)"
           [style.padding-bottom]="loaderService.getHeight(plate)"
@@ -112,7 +112,7 @@
       class="ion-no-padding"
       style="margin: 0 3px 8px 3px;"
       size="auto"
-      *ngIf="compCollars && weightUnitService.userUnit!=='lb'">
+      *ngIf="compCollars && (weightUnitService.userUnit | async) !== 'lb'">
       <ion-badge
         [color]="loaderService.getKGBadgeColor(2.5)"
         style="padding-top: 5px; padding-bottom: 5px;"

--- a/src/app/loader/bar-loader/bar-loader.component.ts
+++ b/src/app/loader/bar-loader/bar-loader.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { WeightUnitService } from 'src/app/settings/weight-unit.service';
 import { LoaderService, Plates } from '../loader.service';
 
@@ -7,7 +7,7 @@ import { LoaderService, Plates } from '../loader.service';
   templateUrl: './bar-loader.component.html',
   styleUrls: ['./bar-loader.component.scss'],
 })
-export class BarLoaderComponent implements OnInit {
+export class BarLoaderComponent implements OnInit, OnDestroy {
   tWeight: number;
   compCollars = true;
   barWeight = 20;
@@ -46,22 +46,33 @@ export class BarLoaderComponent implements OnInit {
     public loaderService: LoaderService
   ) { }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.weightUnitService.userUnit.subscribe(() =>
+      this.onCalcBar()
+    );
+  }
+
+  ngOnDestroy() {
+    this.weightUnitService.userUnit.unsubscribe();
+  }
+
 
   onCalcBar(): void {
-    if (this.weightUnitService.userUnit === 'kg') {
+    const unitUsed = this.weightUnitService.userUnit.value;
+
+    if (unitUsed === 'kg') {
       if (
         (this.compCollars && (this.tWeight > (this.barWeight + this.collarsWeight))) ||
         (!this.compCollars && (this.tWeight > this.barWeight + this.collarsWeight))
       ) {
         this.barLoaded = this.loaderService.weightToBarLoad(
-          this.tWeight, this.plateCount[this.weightUnitService.userUnit], this.barWeight, this.compCollars
+          this.tWeight, this.plateCount[unitUsed], this.barWeight, this.compCollars
         );
       }
-    } else if (this.weightUnitService.userUnit === 'lb') {
+    } else if (unitUsed === 'lb') {
       if (this.tWeight > this.barWeight) {
         this.barLoaded = this.loaderService.weightToBarLoad(
-          this.tWeight, this.plateCount[this.weightUnitService.userUnit], 45, false
+          this.tWeight, this.plateCount[unitUsed], 45, false
         );
       }
     }

--- a/src/app/loader/bar-loader/bar-loader.component.ts
+++ b/src/app/loader/bar-loader/bar-loader.component.ts
@@ -19,16 +19,26 @@ export class BarLoaderComponent implements OnInit {
 
   showPlates = false;
   plateText = 'Configure available plates';
-  plateCount: Array<Plates> = [
-    { weight: 50, pairs: 0 },
-    { weight: 25, pairs: 8 },
-    { weight: 20, pairs: 1 },
-    { weight: 15, pairs: 1 },
-    { weight: 10, pairs: 1 },
-    { weight: 5, pairs: 1 },
-    { weight: 2.5, pairs: 1 },
-    { weight: 1.25, pairs: 1 }
-  ];
+  plateCount: {[unit: string]: Array<Plates>} = {
+    kg: [
+      { weight: 50, pairs: 0 },
+      { weight: 25, pairs: 8 },
+      { weight: 20, pairs: 1 },
+      { weight: 15, pairs: 1 },
+      { weight: 10, pairs: 1 },
+      { weight: 5, pairs: 1 },
+      { weight: 2.5, pairs: 1 },
+      { weight: 1.25, pairs: 1 }
+    ],
+    lb: [
+      { weight: 45, pairs: 8 },
+      { weight: 35, pairs: 0 },
+      { weight: 25, pairs: 1 },
+      { weight: 10, pairs: 1 },
+      { weight: 5, pairs: 1 },
+      { weight: 2.5, pairs: 1 }
+    ]
+  };
   barLoaded: any[];
 
   constructor(
@@ -39,14 +49,23 @@ export class BarLoaderComponent implements OnInit {
   ngOnInit() {}
 
   onCalcBar(): void {
-    if (
-      (this.compCollars && (this.weightUnitService.convertToKilo(this.tWeight) > (this.barWeight + this.collarsWeight))) ||
-      (!this.compCollars && (this.weightUnitService.convertToKilo(this.tWeight) > this.barWeight + this.collarsWeight))
-    ) {
-      this.barLoaded = this.loaderService.weightToBarLoad(
-        this.weightUnitService.convertToKilo(this.tWeight), this.plateCount, this.barWeight, this.compCollars
-      );
-    } else {
+    if (this.weightUnitService.userUnit === 'kg') {
+      if (
+        (this.compCollars && (this.tWeight > (this.barWeight + this.collarsWeight))) ||
+        (!this.compCollars && (this.tWeight > this.barWeight + this.collarsWeight))
+      ) {
+        this.barLoaded = this.loaderService.weightToBarLoad(
+          this.tWeight, this.plateCount[this.weightUnitService.userUnit], this.barWeight, this.compCollars
+        );
+      }
+    } else if (this.weightUnitService.userUnit === 'lb') {
+      if (this.tWeight > this.barWeight) {
+        this.barLoaded = this.loaderService.weightToBarLoad(
+          this.tWeight, this.plateCount[this.weightUnitService.userUnit], 45, false
+        );
+      }
+    }
+    else {
       this.barLoaded = null;
     }
   }

--- a/src/app/loader/bar-loader/bar-loader.component.ts
+++ b/src/app/loader/bar-loader/bar-loader.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { WeightUnitService } from 'src/app/settings/weight-unit.service';
 import { LoaderService, Plates } from '../loader.service';
 
 @Component({
@@ -30,17 +31,20 @@ export class BarLoaderComponent implements OnInit {
   ];
   barLoaded: any[];
 
-  constructor(public loaderService: LoaderService) { }
+  constructor(
+    public weightUnitService: WeightUnitService,
+    public loaderService: LoaderService
+  ) { }
 
   ngOnInit() {}
 
   onCalcBar(): void {
     if (
-      (this.compCollars && (this.tWeight > (this.barWeight + this.collarsWeight))) ||
-      (!this.compCollars && (this.tWeight > this.barWeight + this.collarsWeight))
+      (this.compCollars && (this.weightUnitService.convertToKilo(this.tWeight) > (this.barWeight + this.collarsWeight))) ||
+      (!this.compCollars && (this.weightUnitService.convertToKilo(this.tWeight) > this.barWeight + this.collarsWeight))
     ) {
       this.barLoaded = this.loaderService.weightToBarLoad(
-        this.tWeight, this.plateCount, this.barWeight, this.compCollars
+        this.weightUnitService.convertToKilo(this.tWeight), this.plateCount, this.barWeight, this.compCollars
       );
     } else {
       this.barLoaded = null;

--- a/src/app/loader/loader.service.ts
+++ b/src/app/loader/loader.service.ts
@@ -34,7 +34,7 @@ export class LoaderService {
   constructor(private weightUnitService: WeightUnitService){}
 
   getHeight(plate: number): string {
-    const heights = (this.weightUnitService.userUnit === 'lb') ?
+    const heights = (this.weightUnitService.userUnit.value === 'lb') ?
       this.handleUnits.lb.heights(plate) : this.handleUnits.kg.heights(plate);
     return `${heights}px`;
   };

--- a/src/app/loader/loader.service.ts
+++ b/src/app/loader/loader.service.ts
@@ -33,78 +33,6 @@ export class LoaderService {
 
   constructor(private weightUnitService: WeightUnitService){}
 
-  kgHeights(plate: number): number {
-    const maxHeight = 80;
-
-    let height: number;
-    switch (plate) {
-      // 25 and 20 are default maxHeight
-      case 15:
-        height = maxHeight * 0.9;
-        break;
-      case 10:
-        height = maxHeight * 0.8;
-        break;
-      case 5:
-        height = maxHeight * 0.7;
-        break;
-      case 2.5:
-        height = maxHeight * 0.6;
-        break;
-      case 1.25:
-        height = maxHeight * 0.5;
-        break;
-      case 1:
-        height = maxHeight * 0.4;
-        break;
-      case 0.5:
-        height = maxHeight * 0.3;
-        break;
-      case 0.25:
-        height = maxHeight * 0.2;
-        break;
-      default:
-        height = maxHeight;
-    }
-    return height;
-  };
-
-  lbHeights(plate: number): number {
-    const maxHeight = 80;
-
-    let height: number;
-    switch (plate) {
-      // 45 is default maxHeight
-      case 25:
-        height = maxHeight * 0.9;
-        break;
-      case 10:
-        height = maxHeight * 0.8;
-        break;
-      case 5:
-        height = maxHeight * 0.7;
-        break;
-      case 2.5:
-        height = maxHeight * 0.6;
-        break;
-      case 1.25:
-        height = maxHeight * 0.5;
-        break;
-      case 1:
-        height = maxHeight * 0.4;
-        break;
-      case 0.5:
-        height = maxHeight * 0.3;
-        break;
-      case 0.25:
-        height = maxHeight * 0.2;
-        break;
-      default:
-        height = maxHeight;
-    }
-    return height;
-  };
-
   getHeight(plate: number): string {
     const heights = (this.weightUnitService.userUnit === 'lb') ?
       this.handleUnits.lb.heights(plate) : this.handleUnits.kg.heights(plate);
@@ -138,10 +66,6 @@ export class LoaderService {
 
   filterPlates(plates: Array<Plate>): Array<Plate> {
     return plates.filter(plate => plate.count > 0);
-  }
-
-  filterPair(plates: Array<Plates>): Array<Plates> {
-    return plates.filter(plate => plate.pairs > 0);
   }
 
   weightToBarLoad = (weight: number, plates: any, barWeight: number, compCollar: boolean) => {
@@ -180,5 +104,81 @@ export class LoaderService {
   // from https://ionicframework.com/docs/angular/performance
   trackItems(index: number, itemObject: any) {
     return itemObject.id;
+  }
+
+  private kgHeights(plate: number): number {
+    const maxHeight = 80;
+
+    let height: number;
+    switch (plate) {
+      // 25 and 20 are default maxHeight
+      case 15:
+        height = maxHeight * 0.9;
+        break;
+      case 10:
+        height = maxHeight * 0.8;
+        break;
+      case 5:
+        height = maxHeight * 0.7;
+        break;
+      case 2.5:
+        height = maxHeight * 0.6;
+        break;
+      case 1.25:
+        height = maxHeight * 0.5;
+        break;
+      case 1:
+        height = maxHeight * 0.4;
+        break;
+      case 0.5:
+        height = maxHeight * 0.3;
+        break;
+      case 0.25:
+        height = maxHeight * 0.2;
+        break;
+      default:
+        height = maxHeight;
+    }
+    return height;
+  };
+
+  private lbHeights(plate: number): number {
+    const maxHeight = 80;
+
+    let height: number;
+    switch (plate) {
+      // 45 is default maxHeight
+      case 25:
+        height = maxHeight * 0.9;
+        break;
+      case 10:
+        height = maxHeight * 0.8;
+        break;
+      case 5:
+        height = maxHeight * 0.7;
+        break;
+      case 2.5:
+        height = maxHeight * 0.6;
+        break;
+      case 1.25:
+        height = maxHeight * 0.5;
+        break;
+      case 1:
+        height = maxHeight * 0.4;
+        break;
+      case 0.5:
+        height = maxHeight * 0.3;
+        break;
+      case 0.25:
+        height = maxHeight * 0.2;
+        break;
+      default:
+        height = maxHeight;
+    }
+    return height;
+  };
+
+  private filterPair(plates: Array<Plates>): Array<Plates> {
+    return plates.filter(plate => plate.pairs > 0);
   }
 }

--- a/src/app/loader/loader.service.ts
+++ b/src/app/loader/loader.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { WeightUnitService } from '../settings/weight-unit.service';
 
 export interface Plates {
   weight: number; pairs: number;
@@ -8,10 +9,30 @@ export interface Plate {
   weight: number; count: number;
 };
 
+interface FunctionHandler {
+  [unit: string]: {
+    heights(plate: number): number;
+    colours(plate: number): string;
+  };
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class LoaderService {
+  handleUnits: FunctionHandler = {
+    kg: {
+      heights: (plate) => this.kgHeights(plate),
+      colours: (plate) => this.getKGBadgeColor(plate)
+    },
+    lb: {
+      heights: (plate) => this.lbHeights(plate),
+      colours: () => 'medium'
+    },
+  };
+
+  constructor(private weightUnitService: WeightUnitService){}
+
   kgHeights(plate: number): number {
     const maxHeight = 80;
 
@@ -48,33 +69,49 @@ export class LoaderService {
     return height;
   };
 
-  getHeight(plate: number): string {
-    const heights = this.kgHeights;
-    return `${heights(plate)}px`;
+  lbHeights(plate: number): number {
+    const maxHeight = 80;
+
+    let height: number;
+    switch (plate) {
+      // 45 is default maxHeight
+      case 25:
+        height = maxHeight * 0.9;
+        break;
+      case 10:
+        height = maxHeight * 0.8;
+        break;
+      case 5:
+        height = maxHeight * 0.7;
+        break;
+      case 2.5:
+        height = maxHeight * 0.6;
+        break;
+      case 1.25:
+        height = maxHeight * 0.5;
+        break;
+      case 1:
+        height = maxHeight * 0.4;
+        break;
+      case 0.5:
+        height = maxHeight * 0.3;
+        break;
+      case 0.25:
+        height = maxHeight * 0.2;
+        break;
+      default:
+        height = maxHeight;
+    }
+    return height;
   };
 
-  kgColours(plate: number): string {
-    switch (plate) {
-      case 25:
-        return 'red';
-      case 20:
-        return 'blue';
-      case 15:
-        return 'yellow';
-      case 10:
-        return 'green';
-      case 5:
-        return 'white';
-      case 2.5:
-        return 'black';
-      case 1.25:
-        return 'gray';
-      default:
-        return 'black';
-    }
-  }
+  getHeight(plate: number): string {
+    const heights = (this.weightUnitService.userUnit === 'lb') ?
+      this.handleUnits.lb.heights(plate) : this.handleUnits.kg.heights(plate);
+    return `${heights}px`;
+  };
 
-  getBadgeColor(plate: number): string {
+  getKGBadgeColor(plate: number): string {
     switch (plate) {
       case 25:
         return 'danger';

--- a/src/app/rpe/rpe.page.html
+++ b/src/app/rpe/rpe.page.html
@@ -23,7 +23,7 @@
                     name="haveWeight"
                     (ngModelChange)="onCalcERM(projected); onCalcELOAD(required)"
                   ></ion-input>
-                  <ion-note slot="end">kg</ion-note>
+                  <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
                 </ion-item>
                 <ion-item>
                   <ion-label position="fixed">reps</ion-label>

--- a/src/app/rpe/rpe.page.html
+++ b/src/app/rpe/rpe.page.html
@@ -23,7 +23,7 @@
                     name="haveWeight"
                     (ngModelChange)="onCalcERM(projected); onCalcELOAD(required)"
                   ></ion-input>
-                  <ion-note slot="end">{{ weightUnitService.userUnit }}</ion-note>
+                  <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
                 </ion-item>
                 <ion-item>
                   <ion-label position="fixed">reps</ion-label>

--- a/src/app/rpe/rpe.page.html
+++ b/src/app/rpe/rpe.page.html
@@ -55,7 +55,7 @@
               <ion-row id="e1rm">
                   e1RM
                   <ion-text class="ion-padding-start" color="danger">
-                    {{ e1rm }}
+                    {{ isNumber(e1rm) ? (e1rm | number : '1.2-2') + 'kg' : e1rm }}
                   </ion-text>
               </ion-row>
             </ion-card-content>
@@ -101,7 +101,7 @@
               <ion-row id="eLoad">
                 eLoad
                 <ion-text class="ion-padding-start" color="success">
-                  {{ eLoad }}
+                  {{ isNumber(eLoad) ? (eLoad | number : '1.2-2') + 'kg' : eLoad }}
                 </ion-text>
               </ion-row>
             </ion-card-content>

--- a/src/app/rpe/rpe.page.html
+++ b/src/app/rpe/rpe.page.html
@@ -55,7 +55,7 @@
               <ion-row id="e1rm">
                   e1RM
                   <ion-text class="ion-padding-start" color="danger">
-                    {{ isNumber(e1rm) ? (e1rm | number : '1.2-2') + 'kg' : e1rm }}
+                    {{ isNumber(e1rm) ? (e1rm | number : '1.2-2') + (weightUnitService.userUnit | async) : e1rm }}
                   </ion-text>
               </ion-row>
             </ion-card-content>
@@ -101,7 +101,7 @@
               <ion-row id="eLoad">
                 eLoad
                 <ion-text class="ion-padding-start" color="success">
-                  {{ isNumber(eLoad) ? (eLoad | number : '1.2-2') + 'kg' : eLoad }}
+                  {{ isNumber(eLoad) ? (eLoad | number : '1.2-2') + (weightUnitService.userUnit | async) : eLoad }}
                 </ion-text>
               </ion-row>
             </ion-card-content>

--- a/src/app/rpe/rpe.page.ts
+++ b/src/app/rpe/rpe.page.ts
@@ -9,8 +9,8 @@ import { WeightUnitService } from '../settings/weight-unit.service';
   styleUrls: ['./rpe.page.scss'],
 })
 export class RpePage implements OnInit {
-  e1rm = '';
-  eLoad = '';
+  e1rm: number | string;
+  eLoad: number | string;
 
   scale: RPEPct = RPEPCTTABLE;
 
@@ -56,14 +56,12 @@ export class RpePage implements OnInit {
           (form.value.haveReps === 14 && form.value.haveRPE >= 9) ||
           (form.value.haveReps === 15 && form.value.haveRPE === 10))
       ) {
-        const e1rm = this.calcMax(
+        this.e1rm = this.calcMax(
           form.value.haveWeight,
           form.value.haveReps,
           form.value.haveRPE
         );
-        if (e1rm) {
-          this.e1rm = e1rm.toFixed(2) + 'kg';
-        } else {
+        if (!this.e1rm) {
           this.e1rm = 'invalid';
         }
       } else {
@@ -91,14 +89,12 @@ export class RpePage implements OnInit {
           (form.value.wantReps === 14 && form.value.wantRPE >= 9) ||
           (form.value.wantReps === 15 && form.value.wantRPE === 10))
       ) {
-        const eLoad = this.calcLoad(
-          +this.e1rm.slice(0, -2),
+        this.eLoad = this.calcLoad(
+          +this.e1rm,
           form.value.wantReps,
           form.value.wantRPE
         );
-        if (eLoad) {
-          this.eLoad = eLoad.toFixed(2) + 'kg';
-        } else {
+        if (!this.eLoad) {
           this.eLoad = 'invalid';
         }
       } else {
@@ -107,5 +103,9 @@ export class RpePage implements OnInit {
     } else {
       this.eLoad = '';
     }
+  }
+
+  isNumber(val: any): boolean { // from https://stackoverflow.com/questions/37511055/how-to-check-type-of-variable-in-ngif-in-angular2
+    return typeof val === 'number';
   }
 }

--- a/src/app/rpe/rpe.page.ts
+++ b/src/app/rpe/rpe.page.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { RPEPct, RPEPCTTABLE } from '../numeric-tables/RPE-pct';
+import { WeightUnitService } from '../settings/weight-unit.service';
 
 @Component({
   selector: 'app-rpe',
@@ -13,7 +14,7 @@ export class RpePage implements OnInit {
 
   scale: RPEPct = RPEPCTTABLE;
 
-  constructor() { }
+  constructor(public weightUnitService: WeightUnitService) { }
 
   ngOnInit() {
   }

--- a/src/app/settings/awake.service.ts
+++ b/src/app/settings/awake.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Storage } from '@capacitor/storage';
+import { KeepAwake } from '@capacitor-community/keep-awake';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AwakeService {
+  allowAwake = false;
+
+  constructor() { }
+
+  setAwake = async (): Promise<void> => {
+    const storeAwake = (this.allowAwake) ? 'awake' : 'sleep';
+
+    await Storage.set({
+      key: 'keep',
+      value: storeAwake
+    });
+  };
+
+  checkAwake = async (): Promise<void> => {
+    const { value } = await Storage.get({ key: 'keep' });
+    if (value) {
+      this.allowAwake = (value === 'awake') ? true : false;
+    }
+  };
+}

--- a/src/app/settings/weight-unit.service.ts
+++ b/src/app/settings/weight-unit.service.ts
@@ -28,10 +28,10 @@ export class WeightUnitService {
   };
 
   convertToKilo(weight: number): number {
-    return (this.userUnit === 'lb') ? weight * LB_IN_KG : weight;
+    return (this.userUnit === 'lb') ? weight / LB_IN_KG : weight;
   }
 
-  converToLb(weight: number): number {
-    return (this.userUnit === 'lb') ? weight / LB_IN_KG : weight;
+  convertToLb(weight: number): number {
+    return (this.userUnit === 'lb') ? weight * LB_IN_KG : weight;
   }
 }

--- a/src/app/settings/weight-unit.service.ts
+++ b/src/app/settings/weight-unit.service.ts
@@ -9,7 +9,9 @@ const LB_IN_KG = 2.2046226218488;
 export class WeightUnitService {
   userUnit = 'kg';
 
-  constructor() { }
+  constructor() {
+    this.checkUnit();
+  }
 
   setUnit = async (): Promise<void> => {
     const storeUnit = (this.userUnit === 'kg') ? 'kg' : 'lb';

--- a/src/app/settings/weight-unit.service.ts
+++ b/src/app/settings/weight-unit.service.ts
@@ -1,12 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Storage } from '@capacitor/storage';
 
-
-type WeightUnit = 'kg' | 'lbs';
-
-const KG: WeightUnit = 'kg';
-const LBS: WeightUnit = 'lbs';
-
 const LB_IN_KG = 2.2046226218488;
 
 @Injectable({
@@ -32,4 +26,12 @@ export class WeightUnitService {
       this.userUnit = (value === 'kg') ? 'kg' : 'lb';
     }
   };
+
+  convertToKilo(weight: number): number {
+    return (this.userUnit === 'lb') ? weight * LB_IN_KG : weight;
+  }
+
+  converToLb(weight: number): number {
+    return (this.userUnit === 'lb') ? weight / LB_IN_KG : weight;
+  }
 }

--- a/src/app/settings/weight-unit.service.ts
+++ b/src/app/settings/weight-unit.service.ts
@@ -14,7 +14,7 @@ export class WeightUnitService {
   }
 
   setUnit = async (): Promise<void> => {
-    const storeUnit = (this.userUnit === 'kg') ? 'kg' : 'lb';
+    const storeUnit = (this.userUnit === 'lb') ? 'lb' : 'kg';
 
     await Storage.set({
       key: 'unit',
@@ -25,7 +25,7 @@ export class WeightUnitService {
   checkUnit = async (): Promise<void> => {
     const { value } = await Storage.get({ key: 'unit' });
     if (value) {
-      this.userUnit = (value === 'kg') ? 'kg' : 'lb';
+      this.userUnit = (value === 'lb') ? 'lb' : 'kg';
     }
   };
 

--- a/src/app/settings/weight-unit.service.ts
+++ b/src/app/settings/weight-unit.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Storage } from '@capacitor/storage';
+import { BehaviorSubject } from 'rxjs';
 
 const LB_IN_KG = 2.2046226218488;
 
@@ -7,14 +8,18 @@ const LB_IN_KG = 2.2046226218488;
   providedIn: 'root'
 })
 export class WeightUnitService {
-  userUnit = 'kg';
+  userUnit = new BehaviorSubject<string>('kg');
 
   constructor() {
     this.checkUnit();
   }
 
-  setUnit = async (): Promise<void> => {
-    const storeUnit = (this.userUnit === 'lb') ? 'lb' : 'kg';
+  setUnit = async (event: any): Promise<void> => {
+  this.userUnit.next(event.detail.value);
+    let storeUnit: string;
+    this.userUnit.subscribe(
+      unit => {storeUnit = (unit === 'lb') ? 'lb' : 'kg';}
+    );
 
     await Storage.set({
       key: 'unit',
@@ -25,15 +30,15 @@ export class WeightUnitService {
   checkUnit = async (): Promise<void> => {
     const { value } = await Storage.get({ key: 'unit' });
     if (value) {
-      this.userUnit = (value === 'lb') ? 'lb' : 'kg';
+      this.userUnit.next((value === 'lb') ? 'lb' : 'kg');
     }
   };
 
   convertToKilo(weight: number): number {
-    return (this.userUnit === 'lb') ? weight / LB_IN_KG : weight;
+    return (this.userUnit.value === 'lb') ? weight / LB_IN_KG : weight;
   }
 
   convertToLb(weight: number): number {
-    return (this.userUnit === 'lb') ? weight * LB_IN_KG : weight;
+    return (this.userUnit.value === 'lb') ? weight * LB_IN_KG : weight;
   }
 }

--- a/src/app/timer/timer.page.html
+++ b/src/app/timer/timer.page.html
@@ -55,7 +55,7 @@
             <ion-list lines="none">
               <ion-item>
                 <ion-label>Keep screen awake</ion-label>
-                <ion-toggle [(ngModel)]="allowAwake" (ionChange)="onToggleAwake()"></ion-toggle>
+                <ion-toggle [(ngModel)]="awakeService.allowAwake" (ionChange)="onToggleAwake()"></ion-toggle>
               </ion-item>
             </ion-list>
           </ion-card-content>

--- a/src/app/timer/timer.page.ts
+++ b/src/app/timer/timer.page.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ToastController, PickerController } from '@ionic/angular';
 import { PickerOptions, PickerColumnOption } from '@ionic/core';
 import { KeepAwake } from '@capacitor-community/keep-awake';
+import { AwakeService } from '../settings/awake.service';
 
 @Component({
   selector: 'app-timer',
@@ -17,17 +18,18 @@ export class TimerPage implements OnInit {
   interval: any;
   lhsButtonText = 'Cancel';
   rhsButtonText = 'Start';
-  allowAwake = false;
 
   setsSelected: number;
   setsCompleted = 0;
 
   constructor(
     public toastController: ToastController,
-    private pickerController: PickerController
+    private pickerController: PickerController,
+    public awakeService: AwakeService
   ) { }
 
   ngOnInit() {
+    this.awakeService.checkAwake();
   }
 
   async showTimePicker() {
@@ -132,7 +134,8 @@ export class TimerPage implements OnInit {
   }
 
   onToggleAwake(): void {
-    if(this.allowAwake && this.timerRunning ) {
+    this.awakeService.setAwake();
+    if(this.awakeService.allowAwake && this.timerRunning ) {
       this.keepAwake();
     } else {
       this.allowSleep();

--- a/src/app/timer/timer.page.ts
+++ b/src/app/timer/timer.page.ts
@@ -125,13 +125,9 @@ export class TimerPage implements OnInit {
     }
   }
 
-  async keepAwake() {
-    await KeepAwake.keepAwake();
-  };
+  keepAwake = async (): Promise<void> => await KeepAwake.keepAwake();
 
-  async allowSleep() {
-    await KeepAwake.allowSleep();
-  }
+  allowSleep = async (): Promise<void> => await KeepAwake.allowSleep();
 
   onToggleAwake(): void {
     this.awakeService.setAwake();
@@ -185,9 +181,7 @@ export class TimerPage implements OnInit {
 		});
 	}
 
-  onSetsChange(): void {
-    this.setsCompleted = 0;
-  }
+  onSetsChange = (): number => this.setsCompleted = 0;
 
   onRemoveSet(): void {
     if (this.setsCompleted > 0 && this.setsSelected){

--- a/src/app/utilities/utilities.component.html
+++ b/src/app/utilities/utilities.component.html
@@ -29,8 +29,15 @@
     <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
   </ion-item>
 </ion-list>
-<ion-row class="ion-justify-content-end ion-margin-top">
-  = {{ totalNum || 0 }}{{ weightUnitService.userUnit | async }} total
+<ion-row class="ion-align-items-center ion-margin-top">
+  <ion-col size="auto">
+     <ion-button size="small" (click)="writeToClipboard()">
+      Copy
+    </ion-button>
+  </ion-col>
+  <ion-col class="ion-text-end">
+    = {{ totalNum || 0 }}{{ weightUnitService.userUnit | async }} total
+  </ion-col>
 </ion-row>
 
 <hr/>
@@ -46,17 +53,22 @@
   </ion-item>
 </ion-list>
 <ion-row class="ion-align-items-center">
-  <ion-buttons class="ion-margin-end">
-    <ion-button (click)="onSwitchConversion()">
-      <ion-icon name="swap-vertical"></ion-icon>
-    </ion-button>
-  </ion-buttons>
-  <div [hidden]="convertedNum">
-    convert to {{ convertedUnit === 'lb' ? 'pounds' : 'kilograms' }}
-  </div>
-  <div [hidden]="!convertedNum">
-    converts to {{ convertedNum| number : '1.2-2' }} {{ convertedUnit }}
-  </div>
+  <ion-col size="auto">
+    <ion-buttons class="ion-margin-end">
+      <ion-button (click)="onSwitchConversion()">
+        <ion-icon name="swap-vertical"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-col>
+  <ion-col>
+    <div [hidden]="convertedNum">
+      convert to {{ convertedUnit === 'lb' ? 'pounds' : 'kilograms' }}
+    </div>
+    <div [hidden]="!convertedNum">
+      converts to {{ convertedNum| number : '1.2-2' }} {{ convertedUnit }}
+    </div>
+  </ion-col>
+
 </ion-row>
   </ion-card-content>
 </ion-card>

--- a/src/app/utilities/utilities.component.html
+++ b/src/app/utilities/utilities.component.html
@@ -46,12 +46,17 @@
   </ion-item>
 </ion-list>
 <ion-row class="ion-align-items-center">
-  <ion-buttons>
+  <ion-buttons class="ion-margin-end">
     <ion-button (click)="onSwitchConversion()">
       <ion-icon name="swap-vertical"></ion-icon>
     </ion-button>
   </ion-buttons>
-  = {{ (convertedNum| number : '1.2-2') || 0.00 }} {{ convertedUnit }}
+  <div [hidden]="convertedNum">
+    convert to {{ convertedUnit === 'lb' ? 'pounds' : 'kilograms' }}
+  </div>
+  <div [hidden]="!convertedNum">
+    converts to {{ convertedNum| number : '1.2-2' }} {{ convertedUnit }}
+  </div>
 </ion-row>
   </ion-card-content>
 </ion-card>

--- a/src/app/utilities/utilities.component.html
+++ b/src/app/utilities/utilities.component.html
@@ -1,0 +1,58 @@
+<ion-card class="ion-no-margin ion-no-padding">
+  <ion-card-content>
+    <ion-list>
+  <ion-item>
+    <ion-label position="fixed">squat</ion-label>
+    <ion-input
+      type="number"
+      [(ngModel)]="squatNum"
+      (ngModelChange)="calcTotal()"
+    ></ion-input>
+    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
+  </ion-item>
+  <ion-item>
+    <ion-label position="fixed">bench</ion-label>
+    <ion-input
+      type="number"
+      [(ngModel)]="benchNum"
+      (ngModelChange)="calcTotal()"
+    ></ion-input>
+    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
+  </ion-item>
+  <ion-item>
+    <ion-label position="fixed">deadlift</ion-label>
+    <ion-input
+      type="number"
+      [(ngModel)]="deadliftNum"
+      (ngModelChange)="calcTotal()"
+    ></ion-input>
+    <ion-note slot="end">{{ weightUnitService.userUnit | async }}</ion-note>
+  </ion-item>
+</ion-list>
+<ion-row class="ion-justify-content-end ion-margin-top">
+  = {{ totalNum || 0 }}{{ weightUnitService.userUnit | async }} total
+</ion-row>
+
+<hr/>
+
+<ion-list lines="none">
+  <ion-item>
+    <ion-input
+      type="number"
+      [(ngModel)]="conversionNum"
+      (ngModelChange)="convertNumber()"
+    ></ion-input>
+    <ion-note slot="end">{{ conversionUnit }}</ion-note>
+  </ion-item>
+</ion-list>
+<ion-row class="ion-align-items-center">
+  <ion-buttons>
+    <ion-button (click)="onSwitchConversion()">
+      <ion-icon name="swap-vertical"></ion-icon>
+    </ion-button>
+  </ion-buttons>
+  = {{ (convertedNum| number : '1.2-2') || 0.00 }} {{ convertedUnit }}
+</ion-row>
+  </ion-card-content>
+</ion-card>
+

--- a/src/app/utilities/utilities.component.spec.ts
+++ b/src/app/utilities/utilities.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { UtilitiesComponent } from './utilities.component';
+
+describe('UtilitiesComponent', () => {
+  let component: UtilitiesComponent;
+  let fixture: ComponentFixture<UtilitiesComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ UtilitiesComponent ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UtilitiesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/utilities/utilities.component.ts
+++ b/src/app/utilities/utilities.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit } from '@angular/core';
+import { WeightUnitService } from '../settings/weight-unit.service';
+
+const LB_IN_KG = 2.2046226218488;
+
+@Component({
+  selector: 'app-utilities',
+  templateUrl: './utilities.component.html',
+  styleUrls: ['./utilities.component.scss'],
+})
+export class UtilitiesComponent implements OnInit {
+  squatNum: number;
+  benchNum: number;
+  deadliftNum: number;
+  totalNum = 0;
+
+  conversionNum: number;
+  conversionUnit: string;
+  convertedNum: number;
+  convertedUnit: string;
+
+  constructor(public weightUnitService: WeightUnitService) { }
+
+  ngOnInit() {
+    if (this.weightUnitService.userUnit.value === 'lb') {
+      this.conversionUnit = 'lb';
+      this.convertedUnit = 'kg';
+    } else {
+      this.conversionUnit = 'kg';
+      this.convertedUnit = 'lb';
+    }
+  }
+
+  calcTotal(): void {
+    const sq = (!this.squatNum) ? 0 : this.squatNum;
+    const bp = (!this.benchNum) ? 0 : this.benchNum;
+    const dl = (!this.deadliftNum) ? 0 : this.deadliftNum;
+    this.totalNum = sq + bp + dl;
+  }
+
+  onSwitchConversion(): void {
+    if (this.conversionUnit === 'lb') {
+      this.conversionUnit = 'kg';
+      this.convertedUnit = 'lb';
+    } else {
+      this.conversionUnit = 'lb';
+      this.convertedUnit = 'kg';
+    }
+    this.convertNumber();
+  }
+
+  convertNumber(): void {
+    if (this.conversionUnit === 'lb') {
+      this.convertedNum = this.conversionNum / LB_IN_KG;
+    } else {
+      this.convertedNum = this.conversionNum * LB_IN_KG;
+    }
+  }
+
+}

--- a/src/app/utilities/utilities.component.ts
+++ b/src/app/utilities/utilities.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Clipboard } from '@capacitor/clipboard';
 import { WeightUnitService } from '../settings/weight-unit.service';
 
 const LB_IN_KG = 2.2046226218488;
@@ -37,6 +38,16 @@ export class UtilitiesComponent implements OnInit {
     const dl = (!this.deadliftNum) ? 0 : this.deadliftNum;
     this.totalNum = sq + bp + dl;
   }
+
+  writeToClipboard = async () => {
+    if (this.totalNum) {
+      await Clipboard.write({
+      // eslint-disable-next-line id-blacklist
+        string: this.totalNum.toString()
+      });
+    }
+
+  };
 
   onSwitchConversion(): void {
     if (this.conversionUnit === 'lb') {


### PR DESCRIPTION
Add support for toggling between kilograms and pounds (although as an engineering student it is obvious that lbs is a made-up unit, unlike 'banana length'.

When toggling between units, the preferred unit will be written to local system storage through Capacitor Storage, and any functions that contain non-linear calculations (ie. coefficients) and visual changes (eg. bar loader) will be shown.

Two simple but useful calculators are also added to the `About` menu - one for adding up SBD split to return a total, and one to convert kg to lb and vice versa.

Closes #11 and #20 